### PR TITLE
add LumiMask

### DIFF
--- a/CatProducer/plugins/LumiMaskProducer.cc
+++ b/CatProducer/plugins/LumiMaskProducer.cc
@@ -1,0 +1,58 @@
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+
+#include "DataFormats/Provenance/interface/LuminosityBlockRange.h"
+
+#include <memory>
+#include <vector>
+#include <string>
+
+using namespace std;
+
+class LumiMaskProducer : public edm::EDProducer
+{
+public:
+  LumiMaskProducer(const edm::ParameterSet& pset);
+  ~LumiMaskProducer() {};
+
+  void produce(edm::Event& event, const edm::EventSetup& eventSetup) override;
+
+private:
+  std::vector<edm::LuminosityBlockRange> luminositySectionsBlockRanges_;
+};
+
+LumiMaskProducer::LumiMaskProducer(const edm::ParameterSet& pset)
+{
+  luminositySectionsBlockRanges_ = pset.getUntrackedParameter< std::vector<edm::LuminosityBlockRange> >("LumiSections");
+  produces<int>("");
+}
+
+void LumiMaskProducer::produce(edm::Event& event, const edm::EventSetup& eventSetup)
+{
+  std::auto_ptr<int> passLumiSelection(new int(0));
+  if ( event.isRealData() ){
+    edm::RunNumber_t             kRun  = event.id().run();
+    edm::LuminosityBlockNumber_t kLumi = event.id().luminosityBlock();
+    for(std::vector<edm::LuminosityBlockRange>::iterator oneLumiRange = luminositySectionsBlockRanges_.begin();
+  	oneLumiRange != luminositySectionsBlockRanges_.end(); ++oneLumiRange){
+      if ( kRun < (*oneLumiRange).startRun() ) {
+  	break;
+      }
+      if ( (*oneLumiRange).endRun() < kRun ) continue;
+      if ( (*oneLumiRange).startLumi() <= kLumi && kLumi <= (*oneLumiRange).endLumi() ){
+  	*passLumiSelection = 1;
+  	break;
+      }
+    }
+  }
+  event.put(passLumiSelection, "");
+}
+
+DEFINE_FWK_MODULE(LumiMaskProducer);

--- a/CatProducer/plugins/PileupWeightProducer.cc
+++ b/CatProducer/plugins/PileupWeightProducer.cc
@@ -58,9 +58,9 @@ PileupWeightProducer::PileupWeightProducer(const edm::ParameterSet& pset)
   puToken_ = pset.getParameter<edm::InputTag>("addPileupInfo");
 
   produces<int>("nTrueInteraction");
-  produces<double>("");
-  produces<double>("up");
-  produces<double>("dn");
+  produces<float>("");
+  produces<float>("up");
+  produces<float>("dn");
 
 }
 

--- a/CatProducer/plugins/PileupWeightProducer.cc
+++ b/CatProducer/plugins/PileupWeightProducer.cc
@@ -70,9 +70,9 @@ void PileupWeightProducer::produce(edm::Event& event, const edm::EventSetup& eve
   event.getByLabel(puToken_, puHandle);
 
   std::auto_ptr<int> nTrueIntr(new int(-1));
-  std::auto_ptr<double> weight(new double(1.));
-  std::auto_ptr<double> weightUp(new double(1.));
-  std::auto_ptr<double> weightDn(new double(1.));
+  std::auto_ptr<float> weight(new float(1.));
+  std::auto_ptr<float> weightUp(new float(1.));
+  std::auto_ptr<float> weightDn(new float(1.));
   
   if ( !event.isRealData() and puHandle.isValid() )
   {

--- a/CatProducer/prod/PAT2CAT_cfg.py
+++ b/CatProducer/prod/PAT2CAT_cfg.py
@@ -37,9 +37,10 @@ catPatConfig(process, runOnMC, postfix, jetAlgo, doTriggerSkim)
 from CATTools.CatProducer.catSetup_cff import *
 catSetup(process, runOnMC, doSecVertex, useRunDependantMC)
 
-from CATTools.CatProducer.catEventContent_cff import catEventContentExtended
+from CATTools.CatProducer.catEventContent_cff import catEventContentExtended, catEventContentRD
 process.out.outputCommands = catEventContentExtended
-
+if not runOnMC:
+  process.out.outputCommands.extend(catEventContentRD)
 process.maxEvents.input = options.maxEvents
 
 process.source.fileNames = options.inputFiles

--- a/CatProducer/python/catEventContent_cff.py
+++ b/CatProducer/python/catEventContent_cff.py
@@ -31,5 +31,5 @@ catEventContentExtended.extend([
     ])
 
 catEventContentRD.extend([
-    'keep *_lumiMask*_*_*'
+    'keep *_lumiMask*_*_*',
 ])

--- a/CatProducer/python/catEventContent_cff.py
+++ b/CatProducer/python/catEventContent_cff.py
@@ -2,6 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 catEventContent = cms.untracked.vstring()
 catEventContentExtended = cms.untracked.vstring()
+catEventContentRD = cms.untracked.vstring()
 
 catEventContent.extend([
     'keep *_catMuons_*_*',
@@ -28,3 +29,7 @@ catEventContentExtended.extend([
     'keep edmTriggerResults_TriggerResults__*',
     'keep *_catTrigger_*_*',
     ])
+
+catEventContentRD.extend([
+    'keep *_lumiMask*_*_*'
+])

--- a/CatProducer/python/catPatSetup_cff.py
+++ b/CatProducer/python/catPatSetup_cff.py
@@ -11,6 +11,11 @@ def catPatConfig(process, runOnMC=True, postfix = "PFlow", jetAlgo="AK5", doTrig
     process.totaEvents = cms.EDProducer("EventCountProducer")
     process.p = cms.Path(process.totaEvents)
 
+    from FWCore.PythonUtilities.LumiList import LumiList
+    process.lumiMask = cms.EDProducer("LumiMaskProducer",
+      LumiSections = LumiList('../prod/Cert_190456-208686_8TeV_22Jan2013ReReco_Collisions12_JSON.txt').getVLuminosityBlockRange())
+    process.p += process.lumiMask
+
     # met cleaning events
     process.load("RecoMET.METFilters.metFilters_cff")
     process.p += process.metFilters

--- a/CatProducer/python/catSetup_cff.py
+++ b/CatProducer/python/catSetup_cff.py
@@ -138,6 +138,10 @@ def catSetup(process, runOnMC=True, doSecVertex=True, runDependantMC=False):
         process.catElectrons.runOnMC = cms.bool(False)
         process.catJets.runOnMC = cms.bool(False)
 
+        from FWCore.PythonUtilities.LumiList import LumiList
+        process.lumiMask = cms.EDProducer("LumiMaskProducer",
+            LumiSections = LumiList('../prod/Cert_190456-208686_8TeV_22Jan2013ReReco_Collisions12_JSON.txt').getVLuminosityBlockRange())
+
     if doSecVertex:
         from TrackingTools.TransientTrack.TransientTrackBuilder_cfi import TransientTrackBuilderESProducer
         setattr(process, "TransientTrackBuilderESProducer", TransientTrackBuilderESProducer)

--- a/CatProducer/python/catSetup_cff.py
+++ b/CatProducer/python/catSetup_cff.py
@@ -138,10 +138,10 @@ def catSetup(process, runOnMC=True, doSecVertex=True, runDependantMC=False):
         process.catElectrons.runOnMC = cms.bool(False)
         process.catJets.runOnMC = cms.bool(False)
 
-        from FWCore.PythonUtilities.LumiList import LumiList
-        process.lumiMask = cms.EDProducer("LumiMaskProducer",
-            LumiSections = LumiList('../prod/Cert_190456-208686_8TeV_22Jan2013ReReco_Collisions12_JSON.txt').getVLuminosityBlockRange())
-        process.p += process.lumiMask
+        #from FWCore.PythonUtilities.LumiList import LumiList
+        #process.lumiMask = cms.EDProducer("LumiMaskProducer",
+        #    LumiSections = LumiList('../prod/Cert_190456-208686_8TeV_22Jan2013ReReco_Collisions12_JSON.txt').getVLuminosityBlockRange())
+        #process.p += process.lumiMask
     if doSecVertex:
         from TrackingTools.TransientTrack.TransientTrackBuilder_cfi import TransientTrackBuilderESProducer
         setattr(process, "TransientTrackBuilderESProducer", TransientTrackBuilderESProducer)

--- a/CatProducer/python/catSetup_cff.py
+++ b/CatProducer/python/catSetup_cff.py
@@ -141,7 +141,7 @@ def catSetup(process, runOnMC=True, doSecVertex=True, runDependantMC=False):
         from FWCore.PythonUtilities.LumiList import LumiList
         process.lumiMask = cms.EDProducer("LumiMaskProducer",
             LumiSections = LumiList('../prod/Cert_190456-208686_8TeV_22Jan2013ReReco_Collisions12_JSON.txt').getVLuminosityBlockRange())
-
+        process.p += process.lumiMask
     if doSecVertex:
         from TrackingTools.TransientTrack.TransientTrackBuilder_cfi import TransientTrackBuilderESProducer
         setattr(process, "TransientTrackBuilderESProducer", TransientTrackBuilderESProducer)


### PR DESCRIPTION
----- Begin Fatal Exception 11-Feb-2016 23:02:59 KST-----------------------
An exception of category 'ProductNotFound' occurred while
   [0] Processing run: 190707 lumi: 197 event: 211301741
   [1] Running path 'p'
   [2] Calling event method for module ColorCoherenceAnalyzer/'cc'
Exception Message:
Principal::getByToken: Found zero products matching all criteria
Looking for type: int
Looking for module label: lumiMask
Looking for productInstanceName:
Looking for process: CAT
   Additional Info:
      [a] If you wish to continue processing events after a ProductNotFound exception,
add "SkipEvent = cms.untracked.vstring('ProductNotFound')" to the "options" PSet in the configuration.

----- End Fatal Exception -------------------------------------------------
## Type                                  Module                   Label       Process

edm::TriggerResults                   "TriggerResults"         ""          "HLT"
edm::TriggerResults                   "TriggerResults"         ""          "RECO"
double                                "recoEventInfo"          "pthat"     "CAT"
double                                "recoEventInfo"          "pvX"       "CAT"
double                                "recoEventInfo"          "pvY"       "CAT"
double                                "recoEventInfo"          "pvZ"       "CAT"
double                                "recoEventInfo"          "qScale"    "CAT"
double                                "recoEventInfo"          "weight"    "CAT"
double                                "recoEventInfo"          "weight1"   "CAT"
double                                "recoEventInfo"          "weight2"   "CAT"
edm::TriggerResults                   "TriggerResults"         ""          "CAT"
int                                   "lumiMask"               ""          "CAT"
int                                   "catVertex"              "nGoodPV"   "CAT"
int                                   "catVertex"              "nPV"       "CAT"
int                                   "recoEventInfo"          "pvN"       "CAT"
vectorcat::Electron                 "catElectrons"           ""          "CAT"
vectorcat::Jet                      "catJets"                ""          "CAT"
vectorcat::MET                      "catMETs"                ""          "CAT"
vectorcat::Muon                     "catMuons"               ""          "CAT"
vectorpat::TriggerObjectStandAlone    "catTrigger"             ""          "CAT"
vectorreco::GenJet                  "selectedPatJetsPFlow"   "genJets"   "CAT"
vectorreco::Vertex                  "catVertex"              ""          "CAT"
